### PR TITLE
React 15 updates

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,6 @@ var Card = React.createClass({
     return div({
       className: props.className,
       style: baseStyle,
-      onLevelChange: this.onLevelChange,
       onClick: this.onClick,
       onMouseOver: this.onOver,
       onMouseOut: this.onOut,

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var React = require('react');
 var div = React.DOM.div;
+var deepcopy = require('deepcopy');
 
 var levels = [{
   boxShadow: "none"
@@ -158,7 +159,7 @@ var Card = React.createClass({
   render: function() {
     var props = this.props;
     var state = this.state;
-		var baseStyle = props.style;
+		var baseStyle = deepcopy(props.style);
 
 		if (props.width) baseStyle.width = props.width;
 		if (props.height) baseStyle.height = props.height;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "design",
     "card"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "deepcopy": "^0.6.3"
+  },
   "devDependencies": {
     "browserify": "^10.2.4",
     "jsdom": "^5.4.3",


### PR DESCRIPTION
This PR has a few updates to make this work better with React 15:

- Remove onLevelChange from div. Fixes #6.
- Fix React 15 warning about mutating style. The suggestion is to clone the style in the render method which is what this does using deepcopy.
- Adds deepcopy as a dependency.

Thanks for this component, it's been handy in a few places for us.